### PR TITLE
[BUGFIX] Ensure working `AvalexConfigurationRepository->findByRootPageUid()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,31 +15,32 @@ jobs:
         php:
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
 
       - name: 'Lint PHP'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -s lint
 
       - name: 'Install testing system'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -s composerUpdate
 
       - name: 'Composer validate'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -s composerValidate
 
       - name: 'Composer normalize'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerNormalize -n
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -s composerNormalize -n
 
       - name: 'CGL'
-        run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
+        run: Build/Scripts/runTests.sh -b podman -n -p ${{ matrix.php }} -s cgl
 
       - name: 'Execute functional tests'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mysql -s functional
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -d mysql -i 8.0 -s functional
 
       - name: 'Execute functional tests'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -d mariadb -i 10.4 -s functional
 
       - name: 'Execute functional tests'
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+        run: Build/Scripts/runTests.sh -b podman -p ${{ matrix.php }} -d postgres -i 10 -s functional

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -202,11 +202,11 @@ Options:
             - 15    maintained until 2027-11-11
             - 16    maintained until 2028-11-09
 
-    -p <8.1|8.2|8.3>
+    -p <8.2|8.3|8.4>
         Specifies the PHP minor version to be used
-            - 8.1: use PHP 8.1
-            - 8.2: use PHP 8.2
+            - 8.2: use PHP 8.2 (default)
             - 8.3: use PHP 8.3
+            - 8.4: use PHP 8.4
 
     -x
         Only with -s functional|unit
@@ -254,7 +254,7 @@ TEST_SUITE="cgl"
 DATABASE_DRIVER=""
 DBMS="sqlite"
 DBMS_VERSION=""
-PHP_VERSION="8.1"
+PHP_VERSION="8.2"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 CGLCHECK_DRY_RUN=0
@@ -291,7 +291,7 @@ while getopts "a:b:d:i:s:p:xy:nhu" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.2|8.3|8.4)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Classes/Domain/Repository/AvalexConfigurationRepository.php
+++ b/Classes/Domain/Repository/AvalexConfigurationRepository.php
@@ -38,24 +38,43 @@ class AvalexConfigurationRepository
         $queryBuilder->setRestrictions(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
 
         try {
-            $configurationRecord = $queryBuilder
+            // define inSet filter for website_root to reuse as conditional AND sorting criteria.
+            $websiteRootInSetFilter = $queryBuilder->expr()->inSet(
+                'website_root',
+                // PostgreSQL has issue using named parameters for inSet(), which may be either an issue how the
+                // ExpressionBuilder compatibility is created by TYPO3 or PostgreSQL itself. Directly use value
+                // directly here which is considerable safe in this place.
+                (string)$websiteRoot,
+            );
+            $queryBuilder
                 ->select('uid', 'api_key', 'domain', 'description')
                 ->from(self::TABLE)
                 ->where(
                     $queryBuilder->expr()->or(
-                        $queryBuilder->expr()->inSet(
-                            'website_root',
-                            $queryBuilder->createNamedParameter($websiteRoot, Connection::PARAM_INT),
-                        ),
+                        $websiteRootInSetFilter,
                         $queryBuilder->expr()->eq(
                             'global',
                             $queryBuilder->createNamedParameter(1, Connection::PARAM_INT),
                         ),
-                    )
-                )
-                ->orderBy('global', 'ASC')
-                ->executeQuery()
-                ->fetchAssociative();
+                    ),
+                );
+
+            // Define correct multi-level sorting to retrieve higher preceding configuration first.
+            // 1st level: $websiteRoot id found in record `website_root` set first, not matching last
+            // 2nd level: for each 1st level sort by GLOBAL = 1 first and not global last.
+            // 3nd level: in case 1st and 2nd level is not unique enough which could happen, uid is added as
+            //            third sorting criteria to ensure a deterministic result set sorting and mitigates
+            //            result randomization.
+            $queryBuilder->getConcreteQueryBuilder()
+                ->orderBy($queryBuilder->expr()->castInt($websiteRootInSetFilter), 'DESC')
+                ->addOrderBy('global', 'DESC')
+                ->addOrderBy('uid', 'ASC');
+
+            // Only first result record is required and result set is limited to one record to ensure correctly
+            // closed result buffer when only retrieving one record even if result holds more records to avoid
+            // issues with some database vendors and drivers.
+            $queryBuilder->setMaxResults(1);
+            $configurationRecord = $queryBuilder->executeQuery()->fetchAssociative();
 
             if ($configurationRecord === false) {
                 $this->logger->error('No Avalex configuration could be found in database for page UID: ' . $websiteRoot);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"source": "https://github.com/jweiland-net/avalex"
 	},
 	"require": {
-		"typo3/cms-core": "^13.0"
+		"php": "^8.2",
+		"typo3/cms-core": "^13.4"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "^2.44",


### PR DESCRIPTION
- **[TASK] Use correct TYPO3 v13 LTS version as minimal constraint**
  Enforce TYPO3 13.4.0 LTS as minimmal version and additionally
  ensure PHP versions.
  
  Used command(s):
  
  ```shell
  composer require \
    "typo3/cms-core":"^13.4" \
    "php":"^8.2"
  ```
  

- **[TASK] Align php version support of `Build/Scripts/runTests.sh`**
  This change aligns the PHP version support for the
  `Build/Scripts/runTests.sh` dispatcher script to
  the version range of supported TYPO3 versions and
  set `8.2` as new default PHP version.
  
  Github action workflow file is adjusted along the
  way.
  

- **[BUGFIX] Ensure working `AvalexConfigurationRepository->findByRootPageUid()`**
  Repository method `AvalexConfigurationRepository->findByRootPageUid()`
  builds a conditinal based query using `inSet()` or a direct value
  filtering and requires a prioritized ordering to retrieve the wanted
  record as first record.
  
  Different database vendors has different requirements which requires
  to compose sql queries precisly and in a deterministic way.
  
  This change ...
  
  *   Avoids `named parameters` for the `inSet()` filter, which does not
      work properly for all database vendors by using the value direct.
  *   Reuse the `inSet()` filter as first sorting criteria (1st level) to
      reflect the matched state as highes priority records, keeping the
      `global` ordering as second level.
  *   Adds `uid` as last sorting criteria (3rd) level to take care of a
      deterministic sorting in case 1st and 2nd level produces multiple
      records to avoid randomized query result retrieval.
  